### PR TITLE
Add minimal Three.js + Ammo.js demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,11 @@
-# glowing-memory
+# Simple 3D Engine Example
+
+This repository contains a minimal browser based 3D engine example using
+[Three.js](https://threejs.org/) for rendering and
+[Ammo.js](https://github.com/kripken/ammo.js/) for physics. The example spawns
+several boxes that fall onto a static ground plane.
+
+## Running
+
+Open `index.html` in a modern browser. No build step is required because the
+example loads libraries directly from a CDN.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8" />
+    <title>Simple 3D Engine</title>
+    <style>
+      body { margin: 0; overflow: hidden; }
+    </style>
+</head>
+<body>
+    <script src="https://cdn.jsdelivr.net/npm/three@0.160.0/build/three.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/ammo.js@0.0.10/ammo.js"></script>
+    <script type="module" src="./src/main.js"></script>
+</body>
+</html>

--- a/src/engine.js
+++ b/src/engine.js
@@ -1,0 +1,105 @@
+export class Engine {
+  constructor({ gravity = { x: 0, y: -9.8, z: 0 } } = {}) {
+    this.gravity = gravity;
+    this.objects = [];
+    this.physicsWorld = null;
+
+    this.scene = new THREE.Scene();
+    this.camera = new THREE.PerspectiveCamera(
+      60,
+      window.innerWidth / window.innerHeight,
+      0.1,
+      1000
+    );
+    this.camera.position.set(0, 5, 10);
+
+    this.renderer = new THREE.WebGLRenderer({ antialias: true });
+    this.renderer.setSize(window.innerWidth, window.innerHeight);
+    document.body.appendChild(this.renderer.domElement);
+
+    const light = new THREE.DirectionalLight(0xffffff, 1);
+    light.position.set(5, 10, 7.5);
+    this.scene.add(light);
+
+    window.addEventListener("resize", () => {
+      this.camera.aspect = window.innerWidth / window.innerHeight;
+      this.camera.updateProjectionMatrix();
+      this.renderer.setSize(window.innerWidth, window.innerHeight);
+    });
+  }
+
+  async initPhysics() {
+    const AmmoLib = await Ammo();
+    const collisionConfiguration = new AmmoLib.btDefaultCollisionConfiguration();
+    const dispatcher = new AmmoLib.btCollisionDispatcher(collisionConfiguration);
+    const broadphase = new AmmoLib.btDbvtBroadphase();
+    const solver = new AmmoLib.btSequentialImpulseConstraintSolver();
+    this.physicsWorld = new AmmoLib.btDiscreteDynamicsWorld(
+      dispatcher,
+      broadphase,
+      solver,
+      collisionConfiguration
+    );
+    this.physicsWorld.setGravity(
+      new AmmoLib.btVector3(this.gravity.x, this.gravity.y, this.gravity.z)
+    );
+    this.Ammo = AmmoLib;
+
+    this._clock = new THREE.Clock();
+  }
+
+  addBox({ width = 1, height = 1, depth = 1, x = 0, y = 0, z = 0, mass = 1 }) {
+    const material = new THREE.MeshStandardMaterial({ color: 0x6699ff });
+    const geometry = new THREE.BoxGeometry(width, height, depth);
+    const mesh = new THREE.Mesh(geometry, material);
+    mesh.position.set(x, y, z);
+    this.scene.add(mesh);
+
+    const transform = new this.Ammo.btTransform();
+    transform.setIdentity();
+    transform.setOrigin(new this.Ammo.btVector3(x, y, z));
+    const motionState = new this.Ammo.btDefaultMotionState(transform);
+    const localInertia = new this.Ammo.btVector3(0, 0, 0);
+    const shape = new this.Ammo.btBoxShape(
+      new this.Ammo.btVector3(width / 2, height / 2, depth / 2)
+    );
+    shape.calculateLocalInertia(mass, localInertia);
+
+    const rbInfo = new this.Ammo.btRigidBodyConstructionInfo(
+      mass,
+      motionState,
+      shape,
+      localInertia
+    );
+    const body = new this.Ammo.btRigidBody(rbInfo);
+    this.physicsWorld.addRigidBody(body);
+
+    this.objects.push({ mesh, body });
+  }
+
+  stepSimulation(delta) {
+    this.physicsWorld.stepSimulation(delta, 10);
+
+    for (const obj of this.objects) {
+      const ms = obj.body.getMotionState();
+      if (ms) {
+        ms.getWorldTransform(this._transformAux1);
+        const p = this._transformAux1.getOrigin();
+        const q = this._transformAux1.getRotation();
+        obj.mesh.position.set(p.x(), p.y(), p.z());
+        obj.mesh.quaternion.set(q.x(), q.y(), q.z(), q.w());
+      }
+    }
+  }
+
+  async start() {
+    this._transformAux1 = new this.Ammo.btTransform();
+    const animate = () => {
+      requestAnimationFrame(animate);
+      const delta = this._clock.getDelta();
+      this.stepSimulation(delta);
+      this.renderer.render(this.scene, this.camera);
+    };
+    animate();
+  }
+}

--- a/src/main.js
+++ b/src/main.js
@@ -1,0 +1,18 @@
+import { Engine } from './engine.js';
+
+async function init() {
+  const engine = new Engine();
+  await engine.initPhysics();
+
+  // ground plane
+  engine.addBox({ width: 20, height: 1, depth: 20, y: -0.5, mass: 0 });
+
+  // falling boxes
+  for (let i = 0; i < 5; i++) {
+    engine.addBox({ x: Math.random() * 4 - 2, y: 2 + i * 2, z: 0 });
+  }
+
+  engine.start();
+}
+
+init();


### PR DESCRIPTION
## Summary
- create a demo browser project that loads three.js and ammo.js from CDN
- implement a simple engine wrapper
- spawn falling boxes on a ground plane
- update README with run instructions

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68429aa951a4832c808f11f3d186b963