### PR TITLE
Add sphere support

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,8 @@
 This repository contains a minimal browser based 3D engine example using
 [Three.js](https://threejs.org/) for rendering and
 [Ammo.js](https://github.com/kripken/ammo.js/) for physics. The example spawns
-several boxes that fall onto a static ground plane.
+several boxes that fall onto a static ground plane. It now also supports
+dynamic spheres that interact with the physics world in the same way.
 
 ## Running
 

--- a/src/engine.js
+++ b/src/engine.js
@@ -77,6 +77,33 @@ export class Engine {
     this.objects.push({ mesh, body });
   }
 
+  addSphere({ radius = 1, x = 0, y = 0, z = 0, mass = 1 }) {
+    const material = new THREE.MeshStandardMaterial({ color: 0xff9966 });
+    const geometry = new THREE.SphereGeometry(radius, 32, 32);
+    const mesh = new THREE.Mesh(geometry, material);
+    mesh.position.set(x, y, z);
+    this.scene.add(mesh);
+
+    const transform = new this.Ammo.btTransform();
+    transform.setIdentity();
+    transform.setOrigin(new this.Ammo.btVector3(x, y, z));
+    const motionState = new this.Ammo.btDefaultMotionState(transform);
+    const localInertia = new this.Ammo.btVector3(0, 0, 0);
+    const shape = new this.Ammo.btSphereShape(radius);
+    shape.calculateLocalInertia(mass, localInertia);
+
+    const rbInfo = new this.Ammo.btRigidBodyConstructionInfo(
+      mass,
+      motionState,
+      shape,
+      localInertia
+    );
+    const body = new this.Ammo.btRigidBody(rbInfo);
+    this.physicsWorld.addRigidBody(body);
+
+    this.objects.push({ mesh, body });
+  }
+
   stepSimulation(delta) {
     this.physicsWorld.stepSimulation(delta, 10);
 

--- a/src/main.js
+++ b/src/main.js
@@ -12,6 +12,16 @@ async function init() {
     engine.addBox({ x: Math.random() * 4 - 2, y: 2 + i * 2, z: 0 });
   }
 
+  // falling spheres
+  for (let i = 0; i < 3; i++) {
+    engine.addSphere({
+      radius: 0.5,
+      x: Math.random() * 4 - 2,
+      y: 6 + i * 2,
+      z: 0,
+    });
+  }
+
   engine.start();
 }
 


### PR DESCRIPTION
## Summary
- extend README with info about spheres
- enable spawning spheres in the engine
- spawn a few spheres in the demo scene

## Testing
- `node -c src/engine.js`
- `node -c src/main.js`


------
https://chatgpt.com/codex/tasks/task_e_68429ba2f2a4832ca5acd0996c1d701c