### PR TITLE
Implement RendererManager pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,9 @@ This repository contains a minimal browser based 3D engine example using
 [Three.js](https://threejs.org/) for rendering and
 [Ammo.js](https://github.com/kripken/ammo.js/) for physics. The example spawns
 several boxes that fall onto a static ground plane. It now also supports
-dynamic spheres that interact with the physics world in the same way.
+dynamic spheres that interact with the physics world in the same way. The engine
+now exposes a rendering pipeline through `RendererManager` and a simple
+`MaterialLib` for material management.
 
 ## Running
 

--- a/index.html
+++ b/index.html
@@ -7,9 +7,16 @@
       body { margin: 0; overflow: hidden; }
     </style>
 </head>
-<body>
-    <script src="https://cdn.jsdelivr.net/npm/three@0.160.0/build/three.min.js"></script>
-    <script src="https://cdn.jsdelivr.net/npm/ammo.js@0.0.10/ammo.js"></script>
-    <script type="module" src="./src/main.js"></script>
-</body>
+  <body>
+      <canvas id="app"></canvas>
+      <script src="https://cdn.jsdelivr.net/npm/three@0.160.0/build/three.min.js"></script>
+      <script src="https://cdn.jsdelivr.net/npm/three@0.160.0/examples/js/postprocessing/EffectComposer.js"></script>
+      <script src="https://cdn.jsdelivr.net/npm/three@0.160.0/examples/js/postprocessing/RenderPass.js"></script>
+      <script src="https://cdn.jsdelivr.net/npm/three@0.160.0/examples/js/postprocessing/SSAOPass.js"></script>
+      <script src="https://cdn.jsdelivr.net/npm/three@0.160.0/examples/js/postprocessing/UnrealBloomPass.js"></script>
+      <script src="https://cdn.jsdelivr.net/npm/three@0.160.0/examples/js/postprocessing/ShaderPass.js"></script>
+      <script src="https://cdn.jsdelivr.net/npm/three@0.160.0/examples/js/shaders/FXAAShader.js"></script>
+      <script src="https://cdn.jsdelivr.net/npm/ammo.js@0.0.10/ammo.js"></script>
+      <script type="module" src="./src/main.js"></script>
+  </body>
 </html>

--- a/src/engine.js
+++ b/src/engine.js
@@ -1,5 +1,7 @@
+import { RendererManager, MaterialLib } from './rendererManager.js';
+
 export class Engine {
-  constructor({ gravity = { x: 0, y: -9.8, z: 0 } } = {}) {
+  constructor({ gravity = { x: 0, y: -9.8, z: 0 }, canvas = null } = {}) {
     this.gravity = gravity;
     this.objects = [];
     this.physicsWorld = null;
@@ -13,9 +15,11 @@ export class Engine {
     );
     this.camera.position.set(0, 5, 10);
 
-    this.renderer = new THREE.WebGLRenderer({ antialias: true });
-    this.renderer.setSize(window.innerWidth, window.innerHeight);
-    document.body.appendChild(this.renderer.domElement);
+    this.canvas = canvas || document.createElement('canvas');
+    document.body.appendChild(this.canvas);
+    RendererManager.scene = this.scene;
+    RendererManager.camera = this.camera;
+    this.renderer = RendererManager.init(this.canvas);
 
     const light = new THREE.DirectionalLight(0xffffff, 1);
     light.position.set(5, 10, 7.5);
@@ -24,7 +28,6 @@ export class Engine {
     window.addEventListener("resize", () => {
       this.camera.aspect = window.innerWidth / window.innerHeight;
       this.camera.updateProjectionMatrix();
-      this.renderer.setSize(window.innerWidth, window.innerHeight);
     });
   }
 
@@ -49,7 +52,7 @@ export class Engine {
   }
 
   addBox({ width = 1, height = 1, depth = 1, x = 0, y = 0, z = 0, mass = 1 }) {
-    const material = new THREE.MeshStandardMaterial({ color: 0x6699ff });
+    const material = MaterialLib.get('box');
     const geometry = new THREE.BoxGeometry(width, height, depth);
     const mesh = new THREE.Mesh(geometry, material);
     mesh.position.set(x, y, z);
@@ -78,7 +81,7 @@ export class Engine {
   }
 
   addSphere({ radius = 1, x = 0, y = 0, z = 0, mass = 1 }) {
-    const material = new THREE.MeshStandardMaterial({ color: 0xff9966 });
+    const material = MaterialLib.get('sphere');
     const geometry = new THREE.SphereGeometry(radius, 32, 32);
     const mesh = new THREE.Mesh(geometry, material);
     mesh.position.set(x, y, z);
@@ -125,7 +128,7 @@ export class Engine {
       requestAnimationFrame(animate);
       const delta = this._clock.getDelta();
       this.stepSimulation(delta);
-      this.renderer.render(this.scene, this.camera);
+      RendererManager.drawFrame(delta);
     };
     animate();
   }

--- a/src/main.js
+++ b/src/main.js
@@ -1,7 +1,8 @@
 import { Engine } from './engine.js';
 
 async function init() {
-  const engine = new Engine();
+  const canvas = document.getElementById('app');
+  const engine = new Engine({ canvas });
   await engine.initPhysics();
 
   // ground plane

--- a/src/rendererManager.js
+++ b/src/rendererManager.js
@@ -1,0 +1,93 @@
+export const MaterialLib = {
+  _materials: new Map(),
+  register(name, material) {
+    this._materials.set(name, material);
+  },
+  get(name) {
+    return this._materials.get(name);
+  },
+};
+
+export const RendererManager = {
+  renderer: null,
+  composer: null,
+  scene: null,
+  camera: null,
+  init(canvas) {
+    this.renderer = new THREE.WebGLRenderer({ canvas, antialias: true });
+    this.renderer.setPixelRatio(window.devicePixelRatio);
+    this.renderer.setSize(window.innerWidth, window.innerHeight);
+    this.renderer.outputEncoding = THREE.sRGBEncoding;
+
+    this.composer = new THREE.EffectComposer(this.renderer);
+    if (this.scene && this.camera) {
+      const renderPass = new THREE.RenderPass(this.scene, this.camera);
+      this.composer.addPass(renderPass);
+      const bloomPass = new THREE.UnrealBloomPass(
+        new THREE.Vector2(window.innerWidth, window.innerHeight),
+        0.5,
+        0.4,
+        0.85
+      );
+      this.composer.addPass(bloomPass);
+      const ssaoPass = new THREE.SSAOPass(
+        this.scene,
+        this.camera,
+        window.innerWidth,
+        window.innerHeight
+      );
+      this.composer.addPass(ssaoPass);
+      const fxaa = new THREE.ShaderPass(THREE.FXAAShader);
+      fxaa.uniforms.resolution.value.set(
+        1 / window.innerWidth,
+        1 / window.innerHeight
+      );
+      this.composer.addPass(fxaa);
+    }
+
+    window.addEventListener('resize', () => {
+      this.renderer.setSize(window.innerWidth, window.innerHeight);
+      this.composer.setSize(window.innerWidth, window.innerHeight);
+      if (this.camera) {
+        this.camera.aspect = window.innerWidth / window.innerHeight;
+        this.camera.updateProjectionMatrix();
+      }
+    });
+
+    return this.renderer;
+  },
+  _performCulling() {
+    if (!this.camera || !this.scene) return;
+    const frustum = new THREE.Frustum();
+    const projScreenMatrix = new THREE.Matrix4();
+    this.camera.updateMatrixWorld();
+    projScreenMatrix.multiplyMatrices(
+      this.camera.projectionMatrix,
+      this.camera.matrixWorldInverse
+    );
+    frustum.setFromProjectionMatrix(projScreenMatrix);
+    this.scene.traverse((obj) => {
+      if (obj.isMesh) {
+        if (!obj.geometry.boundingSphere) {
+          obj.geometry.computeBoundingSphere();
+        }
+        const sphere = obj.geometry.boundingSphere
+          .clone()
+          .applyMatrix4(obj.matrixWorld);
+        obj.visible = frustum.intersectsSphere(sphere);
+      }
+    });
+  },
+  drawFrame(dt) {
+    this._performCulling();
+    if (this.composer) {
+      this.composer.render(dt);
+    } else if (this.renderer && this.scene && this.camera) {
+      this.renderer.render(this.scene, this.camera);
+    }
+  },
+};
+
+// default materials
+MaterialLib.register('box', new THREE.MeshStandardMaterial({ color: 0x6699ff }));
+MaterialLib.register('sphere', new THREE.MeshStandardMaterial({ color: 0xff9966 }));


### PR DESCRIPTION
## Summary
- add `RendererManager` and `MaterialLib`
- integrate new pipeline into `Engine`
- expose a canvas element for rendering
- register example materials and use them
- document the new pipeline usage

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68429f486cd8832ca936e3e575fbb301