### PR TITLE
Add basic in-engine editor and profiler

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,17 @@ This repository contains a minimal browser based 3D engine example using
 several boxes that fall onto a static ground plane. It now also supports
 dynamic spheres that interact with the physics world in the same way.
 
+The project now includes a lightweight in-engine editor with a scene inspector,
+gizmo controls and a simple command console. A small profiler utility can be
+used to capture average FPS and CPU timing.
+
 ## Running
 
 Open `index.html` in a modern browser. No build step is required because the
-example loads libraries directly from a CDN.
+example loads libraries directly from a CDN. The editor opens automatically
+when the scene starts. To capture profiling information programmatically call:
+
+```javascript
+const profiler = new Profiler(engine.renderer);
+profiler.capture(1000).then(console.log);
+```

--- a/src/editor.js
+++ b/src/editor.js
@@ -1,0 +1,66 @@
+export class Editor {
+  constructor(engine) {
+    this.engine = engine;
+    this.gui = null;
+    this.controls = null;
+    this.consoleInput = null;
+  }
+
+  async open() {
+    if (this.gui) return;
+    const { GUI } = await import('https://cdn.jsdelivr.net/npm/lil-gui@0.18/+esm');
+    const { TransformControls } = await import('https://cdn.jsdelivr.net/npm/three@0.160.0/examples/jsm/controls/TransformControls.js');
+
+    this.gui = new GUI();
+    const folder = this.gui.addFolder('Inspector');
+
+    const names = this.engine.objects.map((_, i) => `Object${i}`);
+    const params = { selected: names[0] || null, mode: 'translate' };
+
+    const select = folder.add(params, 'selected', [null, ...names]);
+    select.onChange((name) => {
+      if (this.controls) {
+        this.controls.detach();
+        this.engine.scene.remove(this.controls);
+      }
+      if (name) {
+        const idx = names.indexOf(name);
+        const obj = this.engine.objects[idx].mesh;
+        this.controls = new TransformControls(this.engine.camera, this.engine.renderer.domElement);
+        this.controls.attach(obj);
+        this.engine.scene.add(this.controls);
+      }
+    });
+
+    folder.add(params, 'mode', ['translate', 'rotate', 'scale']).onChange((m) => {
+      if (this.controls) this.controls.setMode(m);
+    });
+    folder.open();
+
+    this.consoleInput = document.createElement('input');
+    this.consoleInput.type = 'text';
+    this.consoleInput.placeholder = 'Console command';
+    this.consoleInput.style.position = 'absolute';
+    this.consoleInput.style.bottom = '0';
+    this.consoleInput.style.left = '0';
+    this.consoleInput.style.width = '100%';
+    document.body.appendChild(this.consoleInput);
+
+    this.consoleInput.addEventListener('keydown', (e) => {
+      if (e.key === 'Enter') {
+        try {
+          /* eslint-disable no-eval */
+          const result = eval(e.target.value);
+          console.log(result);
+        } catch (err) {
+          console.error(err);
+        }
+        e.target.value = '';
+      }
+    });
+  }
+
+  update() {
+    if (this.controls) this.controls.update();
+  }
+}

--- a/src/engine.js
+++ b/src/engine.js
@@ -125,6 +125,9 @@ export class Engine {
       requestAnimationFrame(animate);
       const delta = this._clock.getDelta();
       this.stepSimulation(delta);
+      if (this.editor && this.editor.update) {
+        this.editor.update();
+      }
       this.renderer.render(this.scene, this.camera);
     };
     animate();

--- a/src/main.js
+++ b/src/main.js
@@ -1,4 +1,6 @@
 import { Engine } from './engine.js';
+import { Editor } from './editor.js';
+import { Profiler } from './profiler.js';
 
 async function init() {
   const engine = new Engine();
@@ -23,6 +25,13 @@ async function init() {
   }
 
   engine.start();
+
+  const editor = new Editor(engine);
+  engine.editor = editor;
+  await editor.open();
+
+  const profiler = new Profiler(engine.renderer);
+  profiler.capture(1000).then((r) => console.log('Profile:', r));
 }
 
 init();

--- a/src/profiler.js
+++ b/src/profiler.js
@@ -1,0 +1,29 @@
+export class Profiler {
+  constructor(renderer) {
+    this.renderer = renderer;
+  }
+
+  async capture(duration = 1000) {
+    const start = performance.now();
+    let last = start;
+    let frames = 0;
+    let cpuTotal = 0;
+
+    return new Promise((resolve) => {
+      const loop = () => {
+        const now = performance.now();
+        cpuTotal += now - last;
+        last = now;
+        frames++;
+        if (now - start >= duration) {
+          const fps = (frames * 1000) / (now - start);
+          const cpuMs = cpuTotal / frames;
+          resolve({ fps, cpuMs, gpuMs: 0 });
+        } else {
+          requestAnimationFrame(loop);
+        }
+      };
+      requestAnimationFrame(loop);
+    });
+  }
+}


### PR DESCRIPTION
## Summary
- implement a lightweight scene editor with gizmos and console
- implement a simple profiler utility
- expose editor and profiler in example
- document new tooling in README

## Testing
- `npm test` *(fails: Could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68429f7a5900832cb9ce68c238050240