### PR TITLE
Add basic UI framework

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@ This repository contains a minimal browser based 3D engine example using
 [Ammo.js](https://github.com/kripken/ammo.js/) for physics. The example spawns
 several boxes that fall onto a static ground plane. It now also supports
 dynamic spheres that interact with the physics world in the same way.
+It now also contains a simple HUD framework with DOM, Canvas2D and WebGL
+sprites. Widgets for an inventory, mini-map and dialog are included.
 
 ## Running
 

--- a/index.html
+++ b/index.html
@@ -6,6 +6,7 @@
     <style>
       body { margin: 0; overflow: hidden; }
     </style>
+    <link rel="stylesheet" href="./src/ui/ui.css" />
 </head>
 <body>
     <script src="https://cdn.jsdelivr.net/npm/three@0.160.0/build/three.min.js"></script>

--- a/src/main.js
+++ b/src/main.js
@@ -1,8 +1,10 @@
 import { Engine } from './engine.js';
+import { UIManager } from './ui/uiManager.js';
 
 async function init() {
   const engine = new Engine();
   await engine.initPhysics();
+  const ui = new UIManager(engine.scene);
 
   // ground plane
   engine.addBox({ width: 20, height: 1, depth: 20, y: -0.5, mass: 0 });
@@ -21,6 +23,12 @@ async function init() {
       z: 0,
     });
   }
+
+  ui.show('inventory', { items: ['Sword', 'Shield'] });
+  ui.show('minimap');
+  ui.show('dialog', { message: 'Welcome to the demo!' });
+
+  ui.widgets.dialog.el.addEventListener('close', () => ui.widgets.dialog.hide());
 
   engine.start();
 }

--- a/src/ui/ui.css
+++ b/src/ui/ui.css
@@ -1,0 +1,48 @@
+#ui-layer {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  pointer-events: none;
+  font-family: sans-serif;
+}
+
+#ui-canvas {
+  position: absolute;
+  top: 0;
+  left: 0;
+  pointer-events: none;
+}
+
+.ui-widget {
+  position: absolute;
+  pointer-events: auto;
+}
+
+.ui-widget.inventory {
+  top: 10px;
+  left: 10px;
+  background: rgba(0,0,0,0.5);
+  color: #fff;
+  padding: 10px;
+  border-radius: 4px;
+}
+
+.ui-widget.minimap {
+  bottom: 10px;
+  right: 10px;
+  width: 150px;
+  height: 150px;
+  background: rgba(0,0,0,0.5);
+}
+
+.ui-widget.dialog {
+  bottom: 20px;
+  left: 50%;
+  transform: translateX(-50%);
+  background: rgba(0,0,0,0.7);
+  color: #fff;
+  padding: 20px;
+  border-radius: 4px;
+}

--- a/src/ui/uiManager.js
+++ b/src/ui/uiManager.js
@@ -1,0 +1,42 @@
+import { InventoryWidget } from './widgets/InventoryWidget.js';
+import { MiniMapWidget } from './widgets/MiniMapWidget.js';
+import { DialogWidget } from './widgets/DialogWidget.js';
+
+export class UIManager {
+  constructor(scene) {
+    this.scene = scene;
+    this.domLayer = document.createElement('div');
+    this.domLayer.id = 'ui-layer';
+    document.body.appendChild(this.domLayer);
+
+    this.canvas = document.createElement('canvas');
+    this.canvas.id = 'ui-canvas';
+    this.ctx = this.canvas.getContext('2d');
+    document.body.appendChild(this.canvas);
+
+    this.resize();
+    window.addEventListener('resize', () => this.resize());
+
+    this.widgets = {
+      inventory: new InventoryWidget('inventory'),
+      minimap: new MiniMapWidget('minimap', scene),
+      dialog: new DialogWidget('dialog')
+    };
+
+    for (const w of Object.values(this.widgets)) {
+      w.attach(this.domLayer);
+    }
+  }
+
+  resize() {
+    this.canvas.width = window.innerWidth;
+    this.canvas.height = window.innerHeight;
+  }
+
+  show(screenId, data = {}) {
+    const widget = this.widgets[screenId];
+    if (widget) {
+      widget.show(data);
+    }
+  }
+}

--- a/src/ui/uiWidget.js
+++ b/src/ui/uiWidget.js
@@ -1,0 +1,30 @@
+export class UIWidget {
+  constructor(id, { classes = [] } = {}) {
+    this.id = id;
+    this.el = document.createElement('div');
+    this.el.classList.add('ui-widget', ...classes);
+    this.el.dataset.widget = id;
+    this.hide();
+  }
+
+  attach(parent) {
+    parent.appendChild(this.el);
+  }
+
+  show(data = {}) {
+    this.el.style.display = 'block';
+    this.update(data);
+  }
+
+  hide() {
+    this.el.style.display = 'none';
+  }
+
+  update(data) {
+    // override in subclasses
+  }
+
+  emit(event, detail = {}) {
+    this.el.dispatchEvent(new CustomEvent(event, { detail }));
+  }
+}

--- a/src/ui/widgets/DialogWidget.js
+++ b/src/ui/widgets/DialogWidget.js
@@ -1,0 +1,15 @@
+import { UIWidget } from '../uiWidget.js';
+
+export class DialogWidget extends UIWidget {
+  constructor(id) {
+    super(id, { classes: ['dialog'] });
+    this.el.innerHTML = '<p class="message"></p><button>Ok</button>';
+    this.message = this.el.querySelector('.message');
+    this.button = this.el.querySelector('button');
+    this.button.addEventListener('click', () => this.emit('close'));
+  }
+
+  update({ message = '' } = {}) {
+    this.message.textContent = message;
+  }
+}

--- a/src/ui/widgets/InventoryWidget.js
+++ b/src/ui/widgets/InventoryWidget.js
@@ -1,0 +1,18 @@
+import { UIWidget } from '../uiWidget.js';
+
+export class InventoryWidget extends UIWidget {
+  constructor(id) {
+    super(id, { classes: ['inventory'] });
+    this.el.innerHTML = '<h3>Inventory</h3><ul class="items"></ul>';
+    this.list = this.el.querySelector('.items');
+  }
+
+  update({ items = [] } = {}) {
+    this.list.innerHTML = '';
+    for (const item of items) {
+      const li = document.createElement('li');
+      li.textContent = item;
+      this.list.appendChild(li);
+    }
+  }
+}

--- a/src/ui/widgets/MiniMapWidget.js
+++ b/src/ui/widgets/MiniMapWidget.js
@@ -1,0 +1,31 @@
+import { UIWidget } from '../uiWidget.js';
+
+export class MiniMapWidget extends UIWidget {
+  constructor(id, scene) {
+    super(id, { classes: ['minimap'] });
+    this.el.innerHTML = '<canvas></canvas>';
+    this.canvas = this.el.querySelector('canvas');
+    this.ctx = this.canvas.getContext('2d');
+
+    this.sprite = new THREE.Sprite(
+      new THREE.SpriteMaterial({ color: 0xffffff, opacity: 0.5 })
+    );
+    this.sprite.scale.set(1, 1, 1);
+    this.sprite.position.set(0, 5, -5);
+    scene.add(this.sprite);
+
+    this.resize();
+    window.addEventListener('resize', () => this.resize());
+  }
+
+  resize() {
+    this.canvas.width = 150;
+    this.canvas.height = 150;
+  }
+
+  update(data = {}) {
+    this.ctx.clearRect(0, 0, this.canvas.width, this.canvas.height);
+    this.ctx.strokeStyle = '#0f0';
+    this.ctx.strokeRect(0, 0, this.canvas.width, this.canvas.height);
+  }
+}


### PR DESCRIPTION
## Summary
- implement UIWidget base class
- add Inventory, MiniMap, and Dialog widgets
- add UIManager to manage widgets, DOM and Canvas2D layers and WebGL sprite
- show example usage of UIManager in main.js
- update index.html to include new CSS
- update README with HUD framework description

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68429f7562d8832cb6ed08d7b1775371