### PR TITLE
Implement networking layer and server

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,3 +10,24 @@ dynamic spheres that interact with the physics world in the same way.
 
 Open `index.html` in a modern browser. No build step is required because the
 example loads libraries directly from a CDN.
+
+## Networking
+
+The `src/net` directory contains a small networking layer with WebSocket and
+WebRTC transports. Clients can connect using:
+
+```javascript
+import { NetClient } from './src/net/index.js';
+const transport = await NetClient.connect('ws://localhost:3000');
+```
+
+Custom serializers can be registered on the replicator via:
+
+```javascript
+import { register } from './src/net/index.js';
+register(1, mySerializer);
+```
+
+An authoritative WebSocket server is available in `server/server.js` and can be
+started with `node server/server.js`. It periodically sends snapshots of the
+world state to all connected clients.

--- a/server/package.json
+++ b/server/package.json
@@ -1,0 +1,6 @@
+{
+  "type": "module",
+  "dependencies": {
+    "ws": "^8.15.1"
+  }
+}

--- a/server/server.js
+++ b/server/server.js
@@ -1,0 +1,34 @@
+import { WebSocketServer } from 'ws';
+import { NetReplicator } from '../src/net/netReplicator.js';
+
+const wss = new WebSocketServer({ port: 3000 });
+const clients = new Set();
+let worldState = [];
+
+wss.on('connection', ws => {
+  const client = { ws, interestArea: null };
+  clients.add(client);
+
+  ws.on('message', msg => {
+    try {
+      const data = JSON.parse(msg);
+      if (data.interestArea) {
+        client.interestArea = data.interestArea;
+      }
+    } catch {}
+  });
+
+  ws.on('close', () => clients.delete(client));
+});
+
+function broadcastSnapshots() {
+  for (const c of clients) {
+    const objects = NetReplicator.filterByInterest(c, worldState);
+    const snapshot = NetReplicator.createSnapshot(objects);
+    c.ws.send(JSON.stringify({ snapshot }));
+  }
+}
+
+setInterval(broadcastSnapshots, 50);
+
+console.log('Authoritative server running on ws://localhost:3000');

--- a/src/net/index.js
+++ b/src/net/index.js
@@ -1,0 +1,2 @@
+export { NetClient } from './netClient.js';
+export { register, NetReplicator } from './netReplicator.js';

--- a/src/net/netClient.js
+++ b/src/net/netClient.js
@@ -1,0 +1,17 @@
+export class NetClient {
+  static async connect(url) {
+    if (url.startsWith('ws')) {
+      const { WebSocketTransport } = await import('./transports/websocket.js');
+      const transport = new WebSocketTransport();
+      await transport.connect(url);
+      return transport;
+    }
+    if (url.startsWith('rtc')) {
+      const { WebRTCTransport } = await import('./transports/webrtc.js');
+      const transport = new WebRTCTransport();
+      await transport.connect(url);
+      return transport;
+    }
+    throw new Error('Unsupported protocol');
+  }
+}

--- a/src/net/netReplicator.js
+++ b/src/net/netReplicator.js
@@ -1,0 +1,50 @@
+class NetReplicatorImpl {
+  constructor() {
+    this.registry = new Map();
+  }
+
+  register(classId, serializer) {
+    this.registry.set(classId, serializer);
+  }
+
+  createSnapshot(objects) {
+    return objects.map(o => {
+      const serializer = this.registry.get(o.classId);
+      return serializer ? serializer.serialize(o) : null;
+    }).filter(Boolean);
+  }
+
+  createDelta(prev, curr) {
+    const delta = [];
+    const prevMap = new Map(prev.map(o => [o.id, o]));
+    for (const obj of curr) {
+      const prevObj = prevMap.get(obj.id);
+      const serializer = this.registry.get(obj.classId);
+      if (!prevObj) {
+        delta.push({ type: 'add', data: serializer.serialize(obj) });
+      } else if (obj.version !== prevObj.version) {
+        delta.push({ type: 'update', data: serializer.serialize(obj) });
+      }
+      prevMap.delete(obj.id);
+    }
+    for (const id of prevMap.keys()) {
+      delta.push({ type: 'remove', id });
+    }
+    return delta;
+  }
+
+  filterByInterest(client, objects) {
+    if (!client.interestArea) return objects;
+    const { x, y, z, radius } = client.interestArea;
+    return objects.filter(o => {
+      const pos = o.position || { x: 0, y: 0, z: 0 };
+      const dx = pos.x - x;
+      const dy = pos.y - y;
+      const dz = pos.z - z;
+      return dx*dx + dy*dy + dz*dz <= radius*radius;
+    });
+  }
+}
+
+export const NetReplicator = new NetReplicatorImpl();
+export const register = NetReplicator.register.bind(NetReplicator);

--- a/src/net/transports/webrtc.js
+++ b/src/net/transports/webrtc.js
@@ -1,0 +1,58 @@
+export class WebRTCTransport {
+  constructor() {
+    this.peer = null;
+    this.channel = null;
+    this.ws = null;
+  }
+
+  connect(url) {
+    const wsUrl = url.replace('rtc:', 'ws:');
+    return new Promise((resolve, reject) => {
+      this.ws = new WebSocket(wsUrl);
+      this.ws.onopen = () => {
+        this.peer = new RTCPeerConnection();
+        this.channel = this.peer.createDataChannel('data');
+        this.channel.onopen = () => resolve();
+        this.channel.onmessage = e => this.onmessage && this.onmessage(e.data);
+
+        this.peer.onicecandidate = event => {
+          if (event.candidate) {
+            this.ws.send(JSON.stringify({ candidate: event.candidate }));
+          }
+        };
+
+        this.peer.createOffer().then(offer => {
+          this.peer.setLocalDescription(offer);
+          this.ws.send(JSON.stringify({ offer }));
+        });
+      };
+
+      this.ws.onmessage = event => {
+        const msg = JSON.parse(event.data);
+        if (msg.answer) {
+          this.peer.setRemoteDescription(new RTCSessionDescription(msg.answer));
+        } else if (msg.candidate) {
+          this.peer.addIceCandidate(new RTCIceCandidate(msg.candidate));
+        }
+      };
+
+      this.ws.onerror = err => reject(err);
+    });
+  }
+
+  send(data) {
+    if (this.channel && this.channel.readyState === 'open') {
+      this.channel.send(data);
+    }
+  }
+
+  onMessage(cb) {
+    this.onmessage = cb;
+  }
+
+  close() {
+    this.channel && this.channel.close();
+    this.peer && this.peer.close();
+    this.ws && this.ws.close();
+  }
+}

--- a/src/net/transports/websocket.js
+++ b/src/net/transports/websocket.js
@@ -1,0 +1,28 @@
+export class WebSocketTransport {
+  constructor() {
+    this.socket = null;
+  }
+
+  connect(url) {
+    return new Promise((resolve, reject) => {
+      this.socket = new WebSocket(url);
+      this.socket.binaryType = 'arraybuffer';
+      this.socket.onopen = () => resolve();
+      this.socket.onerror = err => reject(err);
+    });
+  }
+
+  send(data) {
+    this.socket && this.socket.send(data);
+  }
+
+  onMessage(cb) {
+    if (this.socket) {
+      this.socket.onmessage = e => cb(e.data);
+    }
+  }
+
+  close() {
+    this.socket && this.socket.close();
+  }
+}


### PR DESCRIPTION
## Summary
- add networking modules with WebSocket/WebRTC transports
- implement NetClient.connect and NetReplicator.register
- provide simple authoritative WebSocket server example
- document networking usage in README

## Testing
- `node --check server/server.js`
- `node --check src/net/netClient.js`
- `node --check src/net/netReplicator.js`
- `node --check src/net/index.js`
- `node --check src/net/transports/websocket.js`
- `node --check src/net/transports/webrtc.js`

------
https://chatgpt.com/codex/tasks/task_e_68429f6e80a8832cbd687c51f88a4ecf