### PR TITLE
Add scripting API with event bus and lifecycle

### DIFF
--- a/dist/main.js
+++ b/dist/main.js
@@ -1,0 +1,28 @@
+import { Engine } from '../src/engine.js';
+import { GameObject, EventBus } from './scripting.js';
+const Spawner = GameObject.extend({
+    update() {
+        if (Math.random() < 0.01) {
+            EventBus.emit('spawnSphere', {
+                x: Math.random() * 4 - 2,
+                y: 8,
+                z: 0
+            });
+        }
+    }
+});
+async function init() {
+    const engine = new Engine();
+    await engine.initPhysics();
+    engine.addBox({ width: 20, height: 1, depth: 20, y: -0.5, mass: 0 });
+    for (let i = 0; i < 5; i++) {
+        engine.addBox({ x: Math.random() * 4 - 2, y: 2 + i * 2, z: 0 });
+    }
+    EventBus.on('spawnSphere', ({ x, y, z }) => {
+        engine.addSphere({ radius: 0.5, x, y, z });
+    });
+    const spawner = new Spawner();
+    engine.addGameObject(spawner);
+    engine.start();
+}
+init();

--- a/dist/scripting.js
+++ b/dist/scripting.js
@@ -1,0 +1,39 @@
+export class GameObject {
+    /**
+     * Extend allows defining lightweight GameObject subclasses via a simple prototype.
+     */
+    static extend(proto) {
+        return class extends GameObject {
+            constructor() {
+                super();
+                Object.assign(this, proto);
+            }
+        };
+    }
+    start() { }
+    update(_delta) { }
+    destroy() { }
+}
+export class EventBus {
+    static on(type, handler) {
+        if (!this.handlers[type])
+            this.handlers[type] = [];
+        this.handlers[type].push(handler);
+    }
+    static off(type, handler) {
+        const list = this.handlers[type];
+        if (!list)
+            return;
+        const idx = list.indexOf(handler);
+        if (idx !== -1)
+            list.splice(idx, 1);
+    }
+    static emit(type, payload) {
+        const list = this.handlers[type];
+        if (!list)
+            return;
+        for (const h of [...list])
+            h(payload);
+    }
+}
+EventBus.handlers = {};

--- a/index.html
+++ b/index.html
@@ -10,6 +10,6 @@
 <body>
     <script src="https://cdn.jsdelivr.net/npm/three@0.160.0/build/three.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/ammo.js@0.0.10/ammo.js"></script>
-    <script type="module" src="./src/main.js"></script>
+    <script type="module" src="./dist/main.js"></script>
 </body>
 </html>

--- a/src/engine.d.ts
+++ b/src/engine.d.ts
@@ -1,0 +1,26 @@
+export interface BoxOptions {
+  width?: number;
+  height?: number;
+  depth?: number;
+  x?: number;
+  y?: number;
+  z?: number;
+  mass?: number;
+}
+
+export interface SphereOptions {
+  radius?: number;
+  x?: number;
+  y?: number;
+  z?: number;
+  mass?: number;
+}
+
+export class Engine {
+  constructor(options?: { gravity?: { x: number; y: number; z: number } });
+  initPhysics(): Promise<void>;
+  addBox(options: BoxOptions): void;
+  addSphere(options: SphereOptions): void;
+  addGameObject(obj: any): void;
+  start(): Promise<void>;
+}

--- a/src/engine.js
+++ b/src/engine.js
@@ -3,6 +3,7 @@ export class Engine {
     this.gravity = gravity;
     this.objects = [];
     this.physicsWorld = null;
+    this.gameObjects = [];
 
     this.scene = new THREE.Scene();
     this.camera = new THREE.PerspectiveCamera(
@@ -104,6 +105,20 @@ export class Engine {
     this.objects.push({ mesh, body });
   }
 
+  addGameObject(obj) {
+    this.gameObjects.push(obj);
+  }
+
+  removeGameObject(obj) {
+    const idx = this.gameObjects.indexOf(obj);
+    if (idx !== -1) {
+      this.gameObjects.splice(idx, 1);
+      if (typeof obj.destroy === "function") {
+        obj.destroy();
+      }
+    }
+  }
+
   stepSimulation(delta) {
     this.physicsWorld.stepSimulation(delta, 10);
 
@@ -121,10 +136,20 @@ export class Engine {
 
   async start() {
     this._transformAux1 = new this.Ammo.btTransform();
+    for (const obj of this.gameObjects) {
+      if (typeof obj.start === "function") {
+        obj.start();
+      }
+    }
     const animate = () => {
       requestAnimationFrame(animate);
       const delta = this._clock.getDelta();
       this.stepSimulation(delta);
+      for (const obj of this.gameObjects) {
+        if (typeof obj.update === "function") {
+          obj.update(delta);
+        }
+      }
       this.renderer.render(this.scene, this.camera);
     };
     animate();

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,0 +1,36 @@
+import { Engine } from '../src/engine.js';
+import { GameObject, EventBus } from './scripting.js';
+
+const Spawner = GameObject.extend({
+  update() {
+    if (Math.random() < 0.01) {
+      EventBus.emit('spawnSphere', {
+        x: Math.random() * 4 - 2,
+        y: 8,
+        z: 0
+      });
+    }
+  }
+});
+
+async function init() {
+  const engine = new Engine();
+  await engine.initPhysics();
+
+  engine.addBox({ width: 20, height: 1, depth: 20, y: -0.5, mass: 0 });
+
+  for (let i = 0; i < 5; i++) {
+    engine.addBox({ x: Math.random() * 4 - 2, y: 2 + i * 2, z: 0 });
+  }
+
+  EventBus.on('spawnSphere', ({ x, y, z }) => {
+    engine.addSphere({ radius: 0.5, x, y, z });
+  });
+
+  const spawner = new Spawner();
+  engine.addGameObject(spawner);
+
+  engine.start();
+}
+
+init();

--- a/src/scripting.ts
+++ b/src/scripting.ts
@@ -1,0 +1,47 @@
+export type GameObjectProto = {
+  start?: () => void;
+  update?: (delta: number) => void;
+  destroy?: () => void;
+};
+
+export class GameObject {
+  /**
+   * Extend allows defining lightweight GameObject subclasses via a simple prototype.
+   */
+  static extend<T extends GameObjectProto>(proto: T) {
+    return class extends GameObject {
+      constructor() {
+        super();
+        Object.assign(this, proto);
+      }
+    } as unknown as { new (): GameObject & T };
+  }
+
+  start(): void {}
+  update(_delta: number): void {}
+  destroy(): void {}
+}
+
+export type EventHandler<T = any> = (payload: T) => void;
+
+export class EventBus {
+  private static handlers: Record<string, EventHandler[]> = {};
+
+  static on(type: string, handler: EventHandler) {
+    if (!this.handlers[type]) this.handlers[type] = [];
+    this.handlers[type].push(handler);
+  }
+
+  static off(type: string, handler: EventHandler) {
+    const list = this.handlers[type];
+    if (!list) return;
+    const idx = list.indexOf(handler);
+    if (idx !== -1) list.splice(idx, 1);
+  }
+
+  static emit(type: string, payload?: any) {
+    const list = this.handlers[type];
+    if (!list) return;
+    for (const h of [...list]) h(payload);
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "ES2019",
+    "module": "ES2020",
+    "strict": true,
+    "moduleResolution": "Node",
+    "rootDir": "src",
+    "outDir": "dist",
+    "esModuleInterop": true
+  },
+  "include": ["src/**/*.ts"]
+}


### PR DESCRIPTION
## Summary
- create TypeScript DSL with `GameObject.extend` and `EventBus`
- manage game object lifecycle inside the engine
- demonstrate usage in TypeScript `main.ts`
- compile to JavaScript in `dist/`
- load compiled script from `index.html`

## Testing
- `npx tsc`


------
https://chatgpt.com/codex/tasks/task_e_68429f682ba0832c94467da91fa5cb3d