### PR TITLE
Implement scene and asset management

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,3 +10,12 @@ dynamic spheres that interact with the physics world in the same way.
 
 Open `index.html` in a modern browser. No build step is required because the
 example loads libraries directly from a CDN.
+
+## Scene and Asset Management
+
+`SceneGraph` provides a simple hierarchy of transform nodes built on top of
+`THREE.Object3D`. Nodes can be added via `SceneGraph.add(node, parent)`.
+
+`AssetLoader` exposes an asynchronous `load(type, url)` method supporting
+`gltf`, `fbx`, `audio` and `texture` assets. Loaded geometries and textures are
+stored in internal pools so they can be reused.

--- a/src/assetLoader.js
+++ b/src/assetLoader.js
@@ -1,0 +1,108 @@
+import { GLTFLoader } from 'https://cdn.jsdelivr.net/npm/three@0.160.0/examples/jsm/loaders/GLTFLoader.js';
+import { FBXLoader } from 'https://cdn.jsdelivr.net/npm/three@0.160.0/examples/jsm/loaders/FBXLoader.js';
+
+export class AssetLoader {
+  constructor() {
+    this.gltfLoader = new GLTFLoader();
+    this.fbxLoader = new FBXLoader();
+    this.audioLoader = new THREE.AudioLoader();
+
+    this.geometryPool = new Map();
+    this.texturePool = new Map();
+  }
+
+  /**
+   * Load an asset asynchronously.
+   * @param {'gltf'|'fbx'|'audio'|'texture'} type - Type of asset.
+   * @param {string} url - URL of the asset.
+   * @returns {Promise<any>} Loaded asset.
+   */
+  async load(type, url) {
+    switch (type) {
+      case 'gltf':
+        return this._loadGLTF(url);
+      case 'fbx':
+        return this._loadFBX(url);
+      case 'audio':
+        return this._loadAudio(url);
+      case 'texture':
+        return this._loadTexture(url);
+      default:
+        throw new Error(`Unknown asset type: ${type}`);
+    }
+  }
+
+  _loadGLTF(url) {
+    return new Promise((resolve, reject) => {
+      this.gltfLoader.load(
+        url,
+        gltf => {
+          this._poolFromObject(gltf.scene);
+          resolve(gltf);
+        },
+        undefined,
+        reject
+      );
+    });
+  }
+
+  _loadFBX(url) {
+    return new Promise((resolve, reject) => {
+      this.fbxLoader.load(
+        url,
+        object => {
+          this._poolFromObject(object);
+          resolve(object);
+        },
+        undefined,
+        reject
+      );
+    });
+  }
+
+  _loadAudio(url) {
+    return new Promise((resolve, reject) => {
+      this.audioLoader.load(url, buffer => resolve(buffer), undefined, reject);
+    });
+  }
+
+  _loadTexture(url) {
+    return new Promise((resolve, reject) => {
+      const loader = new THREE.TextureLoader();
+      loader.load(
+        url,
+        texture => {
+          this.texturePool.set(texture.uuid, texture);
+          resolve(texture);
+        },
+        undefined,
+        reject
+      );
+    });
+  }
+
+  _poolFromObject(object) {
+    object.traverse(child => {
+      if (child.isMesh) {
+        const geom = child.geometry;
+        if (geom && !this.geometryPool.has(geom.uuid)) {
+          this.geometryPool.set(geom.uuid, geom);
+        }
+        const material = child.material;
+        if (material) {
+          const materials = Array.isArray(material) ? material : [material];
+          for (const mat of materials) {
+            for (const key of Object.keys(mat)) {
+              const value = mat[key];
+              if (value instanceof THREE.Texture) {
+                if (!this.texturePool.has(value.uuid)) {
+                  this.texturePool.set(value.uuid, value);
+                }
+              }
+            }
+          }
+        }
+      }
+    });
+  }
+}

--- a/src/sceneGraph.js
+++ b/src/sceneGraph.js
@@ -1,0 +1,20 @@
+export class TransformNode extends THREE.Object3D {
+  constructor() {
+    super();
+  }
+}
+
+export class SceneGraph {
+  constructor() {
+    this.root = new TransformNode();
+  }
+
+  /**
+   * Add a node to the scene graph.
+   * @param {THREE.Object3D} node - Node to add.
+   * @param {THREE.Object3D} [parent=this.root] - Parent node.
+   */
+  add(node, parent = this.root) {
+    parent.add(node);
+  }
+}


### PR DESCRIPTION
## Summary
- add SceneGraph utility with TransformNode hierarchy
- implement AssetLoader with async GLTF/FBX/Audio loading and pooling
- document new APIs

## Testing
- `node -e "globalThis.THREE={Object3D:class{add(){}}};import('./src/sceneGraph.js').then(()=>console.log('ok')).catch(e=>console.error(e))"`
- `node -e "globalThis.THREE={AudioLoader:class{},TextureLoader:class{load(u,c){c({uuid:'t'})}},Texture:Object,Object3D:class{add(){}}};import('./src/assetLoader.js').then(m=>console.log('loaded')).catch(e=>console.error('error',e.message))"`

------
https://chatgpt.com/codex/tasks/task_e_68429f54a828832caa3a9698f7ac118f